### PR TITLE
Fix fields method to follow airtable spec

### DIFF
--- a/api/src/main/java/dev/fuxing/airtable/AirtableApi.java
+++ b/api/src/main/java/dev/fuxing/airtable/AirtableApi.java
@@ -426,7 +426,7 @@ public class AirtableApi {
         @Override
         public AirtableTable.QuerySpec fields(List<String> fields) {
             for (int i = 0; i < fields.size(); i++) {
-                builder.setParameter("fields[" + i + "]", fields.get(i));
+                builder.setParameter("fields[]", fields.get(i));
             }
             return this;
         }

--- a/api/src/main/java/dev/fuxing/airtable/AirtableApi.java
+++ b/api/src/main/java/dev/fuxing/airtable/AirtableApi.java
@@ -79,7 +79,7 @@ public class AirtableApi {
      *
      * @see AirtableApplication inteface for all available methods.
      */
-    public final class Application implements AirtableApplication {
+    public class Application implements AirtableApplication {
         private final String base;
 
         private Application(String base) {
@@ -100,7 +100,7 @@ public class AirtableApi {
      *
      * @see AirtableTable interface for all available methods.
      */
-    public final class Table implements AirtableTable {
+    public class Table implements AirtableTable {
         private final String base;
         private final String table;
 
@@ -276,9 +276,7 @@ public class AirtableApi {
                         .setHost("api.airtable.com")
                         .setPathSegments("v0", base, table);
 
-                recordIds.forEach(s -> {
-                    uriBuilder.addParameter("records[]", s);
-                });
+                recordIds.forEach(s -> uriBuilder.addParameter("records[]", s));
 
                 Request request = Request.Delete(uriBuilder.build())
                         .addHeader("Authorization", "Bearer " + apiKey);
@@ -426,7 +424,7 @@ public class AirtableApi {
         @Override
         public AirtableTable.QuerySpec fields(List<String> fields) {
             for (int i = 0; i < fields.size(); i++) {
-                builder.setParameter("fields[]", fields.get(i));
+                builder.addParameter("fields[]", fields.get(i));
             }
             return this;
         }

--- a/api/src/main/java/dev/fuxing/airtable/AirtableRecord.java
+++ b/api/src/main/java/dev/fuxing/airtable/AirtableRecord.java
@@ -178,7 +178,7 @@ public class AirtableRecord {
      * @param value to be mapped into JsonNode
      */
     public void putField(String name, Object value) {
-        putField(name, OBJECT_MAPPER.valueToTree(value));
+        putField(name, (JsonNode) OBJECT_MAPPER.valueToTree(value));
     }
 
     /**

--- a/api/src/test/java/dev/fuxing/airtable/AirtableApiQueryTest.java
+++ b/api/src/test/java/dev/fuxing/airtable/AirtableApiQueryTest.java
@@ -150,8 +150,8 @@ class AirtableApiQueryTest {
         // Filter By Formula, separated into another method
 
         // Fields
-        assertEquals(query -> query.fields("a", "b"), "fields%5B0%5D=a&fields%5B1%5D=b");
-        assertEquals(query -> query.fields(Collections.singletonList("Space Word")), "fields%5B0%5D=Space+Word");
+        assertEquals(query -> query.fields("a", "b"), "fields%5B%5D=a&fields%5B%5D=b");
+        assertEquals(query -> query.fields(Collections.singletonList("Space Word")), "fields%5B%5D=Space+Word");
 
         // Offset
         assertEquals(query -> query.offset("recidexample"), "offset=recidexample");


### PR DESCRIPTION
When adding `fields[21]` (more than 21 fields), airtable API throws an error such as:
```json
{
	"error": {
		"type": "INVALID_REQUEST_UNKNOWN",
		"message": "Invalid request: parameter validation failed. Check your request data."
	}
}
```
Don't ask me why this breaks airtable, but according to the airtable api docs, the list of fields params should only include the brackets, not a number. Here's an example from their docs:


> For example, to only return data from Event Name and Performers, send these two query parameters:
  `fields%5B%5D=Fieldname1&fields%5B%5D=Fieldname2`
   Note: %5B%5D may be omitted when specifying multiple fields, but must always be included when specifying only a single field.

Submitting the requests without the numeric indexes in the fields[] works fine with 21 or more fields in the list.